### PR TITLE
update MIT to GNU FDL to match actual license

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: Libbitcoin Docs
-copyright: MIT
+copyright: GNU FDL
 theme:
   name: material
   logo: assets/libbitcoin-logo.svg


### PR DESCRIPTION
the license file itself is GNU FDL
so update the footer to GNU Free Documentation License as well